### PR TITLE
Fixes Issue #6: Adds horizontal option for counters

### DIFF
--- a/src/Components/DemandArea.tsx
+++ b/src/Components/DemandArea.tsx
@@ -75,7 +75,7 @@ const DemandArea: React.FC<DemandAreaProps> = () => {
           label={demand.drinks.toString()}
           onIncrement={handleAddDrink}
           onDecrement={handleRemoveDrink}
-          horizontal={true}
+          horizontal
         />
         <ToggleButton
           label="+$5 on Drinks"
@@ -90,7 +90,7 @@ const DemandArea: React.FC<DemandAreaProps> = () => {
           label={demand.burgers.toString()}
           onIncrement={handleAddBurgers}
           onDecrement={handleRemoveBurgers}
-          horizontal={true}
+          horizontal
         />
         <ToggleButton
           label="+$5 on Burger"
@@ -106,7 +106,7 @@ const DemandArea: React.FC<DemandAreaProps> = () => {
           label={demand.pizza.toString()}
           onIncrement={handleAddPizza}
           onDecrement={handleRemovePizza}
-          horizontal={true}
+          horizontal
         />
         <ToggleButton
           label="+$5 on Pizza"

--- a/src/Components/DemandArea.tsx
+++ b/src/Components/DemandArea.tsx
@@ -75,6 +75,7 @@ const DemandArea: React.FC<DemandAreaProps> = () => {
           label={demand.drinks.toString()}
           onIncrement={handleAddDrink}
           onDecrement={handleRemoveDrink}
+          horizontal={true}
         />
         <ToggleButton
           label="+$5 on Drinks"
@@ -89,6 +90,7 @@ const DemandArea: React.FC<DemandAreaProps> = () => {
           label={demand.burgers.toString()}
           onIncrement={handleAddBurgers}
           onDecrement={handleRemoveBurgers}
+          horizontal={true}
         />
         <ToggleButton
           label="+$5 on Burger"
@@ -104,6 +106,7 @@ const DemandArea: React.FC<DemandAreaProps> = () => {
           label={demand.pizza.toString()}
           onIncrement={handleAddPizza}
           onDecrement={handleRemovePizza}
+          horizontal={true}
         />
         <ToggleButton
           label="+$5 on Pizza"

--- a/src/Components/NumberButton.tsx
+++ b/src/Components/NumberButton.tsx
@@ -4,20 +4,31 @@ type NumberButtonProps = {
     label: string;
     onIncrement: () => void;
     onDecrement: () => void;
+    horizontal?: boolean;
   };
   
   const NumberButton: React.FC<NumberButtonProps> = ({
     label,
     onIncrement,
     onDecrement,
+    horizontal = false,
   }) => {
-    return (
+    const verticalCounter = (
       <div className='numberCruncher'>
         <button onClick={onIncrement}>▲</button>
         <span>{label}</span>
         <button onClick={onDecrement}>▼</button>
       </div>
     );
+    const horizontalCounter = (
+      <div className='numberCruncher' style={{display: 'flex', 
+      flexDirection: 'row', justifyContent: 'space-between'}}>
+        <button onClick={onDecrement}>◀</button>
+        <span>{label}</span>
+        <button onClick={onIncrement}>▶</button>
+      </div>
+    );
+    return horizontal ? horizontalCounter : verticalCounter;
   };
   
 

--- a/src/Components/NumberButton.tsx
+++ b/src/Components/NumberButton.tsx
@@ -6,21 +6,28 @@ type NumberButtonProps = {
     onDecrement: () => void;
     horizontal?: boolean;
   };
-  
-  const NumberButton: React.FC<NumberButtonProps> = ({
+
+
+const VerticalCounter: React.FC<Omit<NumberButtonProps, 'horizontal'>> = ({
     label,
     onIncrement,
     onDecrement,
-    horizontal = false,
   }) => {
-    const verticalCounter = (
+    return (
       <div className='numberCruncher'>
         <button onClick={onIncrement}>▲</button>
         <span>{label}</span>
         <button onClick={onDecrement}>▼</button>
       </div>
     );
-    const horizontalCounter = (
+  };
+
+const HorizontalCounter: React.FC<Omit<NumberButtonProps, 'horizontal'>> = ({
+    label,
+    onIncrement,
+    onDecrement,
+  }) => {
+    return (
       <div className='numberCruncher' style={{display: 'flex', 
       flexDirection: 'row', justifyContent: 'space-between'}}>
         <button onClick={onDecrement}>◀</button>
@@ -28,8 +35,24 @@ type NumberButtonProps = {
         <button onClick={onIncrement}>▶</button>
       </div>
     );
-    return horizontal ? horizontalCounter : verticalCounter;
   };
-  
+
+const NumberButton: React.FC<NumberButtonProps> = ({
+    label,
+    onIncrement,
+    onDecrement,
+    horizontal = false,
+  }) => {
+      return ( horizontal
+        ? <HorizontalCounter 
+            label={label} 
+            onIncrement={onIncrement} 
+            onDecrement={onDecrement} /> 
+        : <VerticalCounter 
+            label={label} 
+            onIncrement={onIncrement} 
+            onDecrement={onDecrement} />
+      );
+  };
 
 export default NumberButton;


### PR DESCRIPTION
Fixes #6.

## Changes

Added via a flag that defaults to false - I already set it to true for the demand buttons but the unit price ones remain vertical.

This saves space in the case of the demand icons - there still needs to be formatting changes e.g. the fact that the buttons demand buttons aren't quite aligned due to differently sized svgs but that's for a different commit.

### Before:

![before](https://github.com/egnwd/food-chain-magnate/assets/19627954/331a6490-b555-409e-938d-99c942da1fe5)

### After:

![after](https://github.com/egnwd/food-chain-magnate/assets/19627954/7487cfa1-be59-4a93-a654-bae8e09e376e)
